### PR TITLE
Making the Quectel interface resistant to spurious messages 

### DIFF
--- a/GPS_Reader.py
+++ b/GPS_Reader.py
@@ -136,9 +136,12 @@ class GPS_Reader():
         print(self._data)
 
 def main():
+    global gps_serv_log
     logging.basicConfig()
+    gps_serv_log=logging.getLogger('Modem_GPS_Service')
+    gps_serv_log.setLevel(logging.DEBUG)
     reader=GPS_Reader()
-    reader.traceNMEA()
+    # reader.traceNMEA()
     reader.readNMEAFrame()
     reader.dataPrint()
 

--- a/Modem_GPS_Parameters.py
+++ b/Modem_GPS_Parameters.py
@@ -57,6 +57,8 @@ def default_param():
     out['trace']= "info"
     out['roaming']=True
     out['timer']=300.
+    out["nb_retry"]=5
+    out["log_at"]=False
 
     modem_gps_parameters=out
 

--- a/Modem_Service_Client.py
+++ b/Modem_Service_Client.py
@@ -52,7 +52,7 @@ def printStatus(rs):
     if rs.SIM_status ==  'READY':
         print("IMSI:",rs.IMSI)
         if rs.registered :
-            print("On:",rs.network_reg," PLMNID:",rs.PLMNID," Network:",rs.network," Radio:",rs.rat," Band:",rs.band," LAC:",rs.lac," RSSI:",rs.rssi,"dBm")
+            print("On:",rs.network_reg," PLMNID:",rs.PLMNID," Network:",rs.network," Radio:",rs.rat," Band:",rs.band," LAC:",rs.lac,"CI:",rs.ci, "RSSI:",rs.rssi,"dBm")
         else :
             print("Not registered - visible operators:\n",rs.operators)
 
@@ -75,13 +75,13 @@ def main():
         print("Communication problem with modem_gps service")
         return
 
-    print("Receive frame=",resp.frameID," :",resp.response)
+    # print("Receive frame=",resp.frameID," :",resp.response)
     if sys.argv[2]=='status' and resp.response == 'OK':
         rs=resp.status
         printStatus(rs)
         if rs.gps_on :
             resp=gps.getGPSPrecision()
-            print("Receive frame=",resp.frameID)
+            # print("Receive frame=",resp.frameID)
             if resp.fix :
                 print("GPS FIXED date:",resp.date, "time:",resp.timestamp)
                 resp=gps.getGPSVector()


### PR DESCRIPTION
The Quectel AT service was not always managing well unexpected answers from the modem
1) Causing the thread to crash
2) Causing the Modem service thread to hang

A new function is now used to analyse all responses and discard the one we don't process without stopping the process

The lock in the modem service has a timeout, if it lapse, then the process stops so systemd can restart it