### PR TITLE
Adding some utility to test the modem

### DIFF
--- a/ATcmd.py
+++ b/ATcmd.py
@@ -1,0 +1,36 @@
+#-------------------------------------------------------------------------------
+# Name:        ATcmd
+# Purpose:     send a single AT command to the modem
+#
+# Author:      Laurent Carré
+#
+# Created:     31/03/2020
+# Copyright:   (c) Laurent Carré Sterwen Technologies 2020
+# Licence:     <your licence>
+#-------------------------------------------------------------------------------
+
+import logging
+import sys
+
+from QuectelAT_Service import *
+
+def main():
+
+    log=logging.getLogger('Modem_GPS_Service')
+    log.addHandler(logging.StreamHandler())
+    log.setLevel(logging.DEBUG)
+    modem=QuectelModem('/dev/ttyUSB2',False,False)
+    # modem.logModemStatus()
+
+    if len(sys.argv) > 1:
+        print("sending:",sys.argv[1])
+        resp=modem.sendATcommand(sys.argv[1],False)
+        for r in resp:
+            print(r)
+
+    modem.close()
+
+
+
+if __name__ == '__main__':
+    main()

--- a/Modem_Service.py
+++ b/Modem_Service.py
@@ -83,16 +83,12 @@ class Modem_Service():
                     break
                 else:
                     # SIM is ready but we have a registration problem
-                    if self._modem.regStatus() == "DENIED" :
-                        # nothing we can do here
+                    if self._modem.regStatus() == "DENIED" or self._modem.regStatus() == "NO REG":
+                        # force to look to all network and then wait
+                        self._modem.selectOperator('AUTO')
+                        # let's stop as we can't do much here
                         break
-                    elif self._modem.regStatus() == "IN PROGRES" :
-                        time.sleep(2.0)
-                    elif self._modem.regStatus() == "NO REG":
-                        # force new registration
-
-                        #if nb_attempt == 2 :
-                        #    return True
+                    else:
                         time.sleep(2.0)
                         # return True
 

--- a/QuectelAT_Service.py
+++ b/QuectelAT_Service.py
@@ -28,7 +28,7 @@ class ModemException(Exception) :
 class QuectelModem():
 
 
-    def __init__(self,ifName,log=False):
+    def __init__(self,ifName,log=False,init=True):
         global modem_log
         modem_log=logging.getLogger('Modem_GPS_Service')
         self._ifname = ifName
@@ -41,8 +41,8 @@ class QuectelModem():
 
         self._isRegistered= False
         self._networkReg="UNKNOWN"
-
-        self.initialize()
+        if init :
+            self.initialize()
         self._operatorNames=None # dictionary PLMN/Operator name
         return
 
@@ -683,7 +683,7 @@ class QuectelModem():
         modem_log.info ("TURNING RADIO OFF AND ON")
         modem_log.debug("Going to flight mode")
         self.sendATcommand("+CFUN=0",raiseException=True)
-        time.sleep(1.0)
+        time.sleep(5.0) # 5 sec recommended by Quectel
         modem_log.debug("Restoring normal mode")
         self.sendATcommand("+CFUN=1",raiseException=True)
         modem_log.info ("Allow 20-30 sec for the modem to restart")

--- a/Reg_test.py
+++ b/Reg_test.py
@@ -1,0 +1,75 @@
+#-------------------------------------------------------------------------------
+# Name:        Test Modem
+# Purpose:     Perform basic testing of the modem function
+#
+# Author:      Laurent Carré
+#
+# Created:     11/02/2020
+# Copyright:   (c) Laurent Carré Sterwen Technologies 2020
+# Licence:     <your licence>
+#-------------------------------------------------------------------------------
+
+import logging
+import sys
+import time
+
+from QuectelAT_Service import *
+
+
+def init(modem):
+    modem.resetCard()
+    time.sleep(5.)
+    # modem.clearFPLMN()
+    # modem.allowRoaming()
+    modem.logModemStatus()
+
+def COPS(modem):
+    resp=modem.sendATcommand("+COPS?")
+    for r in resp:
+        print(r)
+
+def CEREG(modem):
+    resp=modem.sendATcommand("+CEREG?")
+    for r in resp:
+        print(r)
+
+def main():
+
+    log=logging.getLogger('Modem_GPS_Service')
+    log.addHandler(logging.StreamHandler())
+    log.setLevel(logging.DEBUG)
+    try:
+        modem=QuectelModem('/dev/ttyUSB2',True)
+    except Exception as err:
+        log.error(str(err))
+        return
+
+    init(modem)
+    log.info("SIM Status:"+modem.SIM_Status())
+    if modem.checkSIM() == "NO SIM":
+        log.error("No SIM card inserted")
+        return
+
+
+    if modem.SIM_Ready():
+        # we have a SIM so look how it goaes
+        COPS(modem)
+        res= modem.networkStatus()
+        CEREG(modem)
+        nb_attempt=0
+        while not res :
+            # let's see what is the situation
+            time.sleep(10.)
+            COPS(modem)
+            res= modem.networkStatus()
+            CEREG(modem)
+            state=modem.regStatus()
+            print("Modem registration status:",state)
+            nb_attempt += 1
+            if nb_attempt > 11: break
+
+    modem.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/Test_Modem.py
+++ b/Test_Modem.py
@@ -1,6 +1,6 @@
 #-------------------------------------------------------------------------------
-# Name:        module1
-# Purpose:
+# Name:        Test Modem
+# Purpose:     Perform basic testing of the modem function
 #
 # Author:      Laurent Carré
 #
@@ -76,13 +76,15 @@ def main():
     elif option == "scan" :
         if modem.SIM_Ready():
             rescan(modem)
+    elif option == 'sms' :
+        checkSMS(modem)
     else:
         modem.allowRoaming()
 
 
     if modem.SIM_Ready():
         # we have a SIM so look how it goaes
-        checkSMS(modem)
+
         res= modem.networkStatus()
 
         if not res :
@@ -98,7 +100,7 @@ def main():
                     res=modem.networkStatus()
                     if res : break
                     nb_attempt += 1
-            if not res:
+            if not res and option == 'list':
                 print(modem.visibleOperators())
                 # try to Register from scratch
                 # clear forbidden PLMN and allow roaming


### PR DESCRIPTION
Last round of tests on the no registration problem.
No SW solution found. This is due to a combination of SIM/modem bug/network

Some small changes:
Test_Modem.py as new options:
- sms to read the sms status
- list to read available networks when no registration works
ATcmd.py is able to send a AT command to the modem. 1 at a time